### PR TITLE
Add ProjectContent persistence

### DIFF
--- a/src/main/java/com/visiplus/portfolio/controllers/ProjectController.java
+++ b/src/main/java/com/visiplus/portfolio/controllers/ProjectController.java
@@ -37,9 +37,10 @@ public class ProjectController {
 
     @PutMapping("/{id}")
     public ResponseEntity<Project> update(@PathVariable String id, @RequestBody Project updated) {
-        return projectRepository.findById(id).map(project -> {
-            updated.setId(project.getId());
-            return ResponseEntity.ok(projectRepository.save(updated));
-        }).orElse(ResponseEntity.notFound().build());
+        Project result = projectService.update(id, updated);
+        if (result == null) {
+            return ResponseEntity.notFound().build();
+        }
+        return ResponseEntity.ok(result);
     }
 }

--- a/src/main/java/com/visiplus/portfolio/repository/ProjectContentRepository.java
+++ b/src/main/java/com/visiplus/portfolio/repository/ProjectContentRepository.java
@@ -1,0 +1,7 @@
+package com.visiplus.portfolio.repository;
+
+import com.visiplus.portfolio.models.ProjectContent;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface ProjectContentRepository extends JpaRepository<ProjectContent, Long> {
+}

--- a/src/main/java/com/visiplus/portfolio/services/ProjectService.java
+++ b/src/main/java/com/visiplus/portfolio/services/ProjectService.java
@@ -4,4 +4,6 @@ import com.visiplus.portfolio.models.Project;
 
 public interface ProjectService {
     Project create(Project project);
+
+    Project update(String id, Project project);
 }

--- a/src/main/java/com/visiplus/portfolio/services/impl/ProjectServiceImpl.java
+++ b/src/main/java/com/visiplus/portfolio/services/impl/ProjectServiceImpl.java
@@ -2,6 +2,8 @@ package com.visiplus.portfolio.services.impl;
 
 import com.visiplus.portfolio.models.Project;
 import com.visiplus.portfolio.repository.ProjectRepository;
+import com.visiplus.portfolio.repository.ProjectContentRepository;
+import com.visiplus.portfolio.models.ProjectContent;
 import com.visiplus.portfolio.services.ProjectService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
@@ -12,12 +14,54 @@ import java.text.Normalizer;
 public class ProjectServiceImpl implements ProjectService {
 
     private final ProjectRepository projectRepository;
+    private final ProjectContentRepository contentRepository;
 
     @Override
     public Project create(Project project) {
         String uniqueSlug = generateUniqueSlug(project.getTitle());
         project.setSlug(uniqueSlug);
-        return projectRepository.save(project);
+        Project savedProject = projectRepository.save(project);
+
+        String contentJson = "{}";
+        if (project.getContent() != null && project.getContent().getContentJson() != null) {
+            contentJson = project.getContent().getContentJson();
+        }
+
+        ProjectContent content = ProjectContent.builder()
+                .project(savedProject)
+                .contentJson(contentJson)
+                .build();
+        contentRepository.save(content);
+        savedProject.setContent(content);
+
+        return savedProject;
+    }
+
+    @Override
+    public Project update(String id, Project updated) {
+        return projectRepository.findById(id).map(existing -> {
+            updated.setId(existing.getId());
+            if (updated.getSlug() == null || updated.getSlug().isEmpty() || !updated.getSlug().equals(existing.getSlug())) {
+                updated.setSlug(generateUniqueSlug(updated.getTitle()));
+            }
+            Project saved = projectRepository.save(updated);
+
+            String json = "{}";
+            if (updated.getContent() != null && updated.getContent().getContentJson() != null) {
+                json = updated.getContent().getContentJson();
+            }
+
+            ProjectContent content = existing.getContent();
+            if (content == null) {
+                content = new ProjectContent();
+                content.setProject(saved);
+            }
+            content.setContentJson(json);
+            contentRepository.save(content);
+            saved.setContent(content);
+
+            return saved;
+        }).orElse(null);
     }
 
     private String generateUniqueSlug(String title) {


### PR DESCRIPTION
## Summary
- add `ProjectContentRepository` for handling ProjectContent entity
- extend `ProjectService` with an `update` method
- persist `ProjectContent` on create and update in `ProjectServiceImpl`
- delegate controller update call to service

## Testing
- `./mvnw test` *(fails: Could not download Maven)*

------
https://chatgpt.com/codex/tasks/task_e_68531dc029a0832786130721d4364ef5